### PR TITLE
mac: add more defaults

### DIFF
--- a/file_managers.py
+++ b/file_managers.py
@@ -1,0 +1,63 @@
+import os
+from urllib.parse import urlparse, unquote
+
+from talon import Context, Module, actions, ui, app
+from talon.mac import applescript
+
+mod = Module()
+ctx = Context()
+ctx.matches = r"""
+os: mac
+"""
+
+# TODO(pcohen): support application names
+setting_terminal = mod.setting(
+    "preferred_terminal",
+    type=str,
+    default="com.apple.Terminal",
+    desc="The application bundle to use in the 'open in terminal' commands (e.g., 'com.apple.Terminal', 'com.googlecode.iterm2')"
+)
+
+@ctx.action_class("user")
+class user_actions:
+    """Default macOS implementations for file managers"""
+
+    def file_manager_current_path():
+        """A generic fallback for that will use `window.doc` to provide the current path
+        in applications that don't implement a more specific function."""
+
+        # NOTE(pcohen): using AXDocument because active_window().doc
+        # returns URL-encoded path sometimes: https://github.com/talonvoice/talon/issues/473
+        window = ui.active_window()
+        try:
+            url = urlparse(window.element.AXDocument)
+            if url.scheme == 'file':  # will there ever be other schemes?
+                return unquote(url.path)
+        except AttributeError:
+            pass
+
+        # Fallback to doc
+        return window.doc
+
+    def file_manager_terminal_here():
+        """Default implementation that opens the current directory in the terminal"""
+        path = actions.user.file_manager_current_path()
+
+        if not path:
+            app.notify("Can't open terminal", "The current application does not report a path to open")
+            return
+
+        if os.path.isfile(path):
+            path = os.path.abspath(os.path.join(path, os.pardir))
+
+        if not os.path.exists(path):
+            app.notify("Can't open terminal", f"The current application reported a path that doesn't exist: {path}")
+            return
+
+        escaped_path = path.replace(r'"', r'\"')
+        applescript.run(rf"""
+            tell application id "{setting_terminal.get()}"
+                activate
+                open "{escaped_path}"
+            end tell
+        """)

--- a/macos_defaults.py
+++ b/macos_defaults.py
@@ -48,6 +48,7 @@ class user_actions:
             return
 
         if os.path.isfile(path):
+            # If the application gave a file, open the terminal in its parent directory.
             path = os.path.abspath(os.path.join(path, os.pardir))
 
         if not os.path.exists(path):

--- a/macos_defaults.py
+++ b/macos_defaults.py
@@ -20,7 +20,7 @@ setting_terminal = mod.setting(
 
 @ctx.action_class("user")
 class user_actions:
-    """Default macOS implementations for file managers"""
+    """Default macOS implementations for user actions"""
 
     def file_manager_current_path():
         """A generic fallback for that will use `window.doc` to provide the current path
@@ -61,3 +61,18 @@ class user_actions:
                 open "{escaped_path}"
             end tell
         """)
+
+@ctx.action_class("edit")
+class Actions:
+    """Default macOS implementations for edit actions"""
+
+    def selected_text() -> str:
+        try:
+            return ui.focused_element().AXSelectedText
+        except Exception:
+            try:
+                # TODO(pcohen): extract this focused_element() -> AXFocusedUIElement fall back
+                # if we will need it more often.
+                return ui.active_app().element.AXFocusedUIElement.AXSelectedText
+            except Exception:
+                return actions.next()

--- a/macos_defaults.py
+++ b/macos_defaults.py
@@ -71,8 +71,8 @@ class Actions:
             return ui.focused_element().AXSelectedText
         except Exception:
             try:
-                # TODO(pcohen): extract this focused_element() -> AXFocusedUIElement fall back
-                # if we will need it more often.
+                # TODO(pcohen): extract this focused_element() -> AXFocusedUIElement fallback
+                # if we expect to need it in the future.
                 return ui.active_app().element.AXFocusedUIElement.AXSelectedText
             except Exception:
                 return actions.next()

--- a/macos_defaults.py
+++ b/macos_defaults.py
@@ -72,6 +72,9 @@ class Actions:
             return ui.focused_element().AXSelectedText
         except Exception:
             try:
+                # ui.focused_element() sometimes returns NoElement.
+                # https://github.com/talonvoice/talon/issues/480
+                #
                 # TODO(pcohen): extract this focused_element() -> AXFocusedUIElement fallback
                 # if we expect to need it in the future.
                 return ui.active_app().element.AXFocusedUIElement.AXSelectedText

--- a/window_doc.py
+++ b/window_doc.py
@@ -1,8 +1,8 @@
 import os
 import subprocess
-from talon import Context, Module, actions, ui, app, clip
 from typing import Optional
-from urllib.parse import urlparse, unquote
+
+from talon import Context, Module, actions, app, clip
 
 ctx = Context()
 mod = Module()
@@ -13,26 +13,6 @@ os: mac
 """
 
 OPEN_CMD_PATH = "/usr/bin/open"
-
-@default_ctx.action_class("user")
-class user_actions:
-    def file_manager_current_path():
-        """A generic fallback for that will use `window.doc` to provide the current path
-        in applications that don't implement a more specific function."""
-
-        # NOTE(pcohen): using AXDocument because active_window().doc
-        # returns URL-encoded path sometimes: https://github.com/talonvoice/talon/issues/473
-        window = ui.active_window()
-        try:
-            url = urlparse(window.element.AXDocument)
-            if url.scheme == 'file':  # will there ever be other schemes?
-                return unquote(url.path)
-        except AttributeError:
-            pass
-
-        # Fallback to doc
-        return window.doc
-
 
 @mod.action_class
 class Actions:


### PR DESCRIPTION
- Add a default implementation of `file_manager_terminal_here()`, so it can work anywhere that `file_manager_current_path()` is defined. The user can can configure their preferred terminal. (Thanks @nriley for the original implementation)
- Moves the default implementation of `file_manager_current_path()`.
- Add a default implementation of `selected_text()` to use accessibility.

References: https://github.com/talonvoice/talon/issues/480