### PR TITLE
accessibility dictation: first round

### DIFF
--- a/dictation/app_overrides/messages.py
+++ b/dictation/app_overrides/messages.py
@@ -1,0 +1,19 @@
+from talon import Context, Module
+
+ctx = Context()
+ctx.matches = """
+os: mac
+app: messages
+"""
+mod = Module()
+
+@ctx.action_class
+class Actions:
+    
+    def accessibility_adjust_context_for_application(el, context):
+        # Messages reports an empty buffer as having None as content instead of "".
+        # We use None as a signal for "accessibility not available", so make sure it is reported as "".
+        if context.content is None:
+            context.content = ""
+        
+        return context

--- a/dictation/app_overrides/messages.py
+++ b/dictation/app_overrides/messages.py
@@ -7,7 +7,7 @@ app: messages
 """
 mod = Module()
 
-@ctx.action_class
+@ctx.action_class("self")
 class Actions:
     
     def accessibility_adjust_context_for_application(el, context):
@@ -17,3 +17,4 @@ class Actions:
             context.content = ""
         
         return context
+

--- a/dictation/debugging.py
+++ b/dictation/debugging.py
@@ -43,13 +43,12 @@ class Actions:
 
             console.rule(f"{str(el)}'s attributes:")
 
-            # Attempt to sort the keys
-            d = {}
+            # Attempt to sort the keys by relying on insertion order.
+            attributed = {}
             for k in sorted(el.attrs):
-                d[k] = el.get(k)
+                attributed[k] = el.get(k)
 
-            console.print(d, markup=False)
-            console.rule("Accessibility contents:")
+            console.print(attributed, markup=False)
         except Exception as e:
             print(f"Exception while debugging accessibility: \"{e}\":")
             traceback.print_exc()

--- a/dictation/debugging.py
+++ b/dictation/debugging.py
@@ -1,17 +1,10 @@
 import time
 import traceback
 
-from talon import (
-    actions,
-    cron,
-    noise,
-    ui,
-)
+from talon import Module, actions, cron, noise, ui
 from talon.mac.ui import Element
 
 HISS_DEBUG_ENABLED = True
-
-from talon import Module
 
 mod = Module()
 setting_enabled = mod.setting(
@@ -27,15 +20,16 @@ setting_threshold = mod.setting(
     desc="If hiss_to_debug_accessibility is enabled, the hissing duration (in seconds) needed to trigger the debug output.",
 )
 
+
 @mod.action_class
 class Actions:
 
     def debug_accessibility(el: Element = None):
-        """short function for debugging accessibility"""
+        """Prints information about the currently focused UI element to the terminal, for debugging"""
 
         if not el:
             el = ui.focused_element()
-        
+
         try:
             # TODO(pcohen): make this work without Rich installed
             from rich.console import Console
@@ -53,13 +47,16 @@ class Actions:
             print(f"Exception while debugging accessibility: \"{e}\":")
             traceback.print_exc()
 
+
 active_hiss = {"cron": None}
+
 
 def hiss_over_threshold():
     if not active_hiss.get("start"):
         return False
 
     return time.time() - active_hiss["start"] > setting_threshold.get()
+
 
 def stop_hiss():
     trigger = hiss_over_threshold()
@@ -73,13 +70,16 @@ def stop_hiss():
     if trigger:
         actions.user.debug_accessibility()
 
+
 def check_hiss():
     if hiss_over_threshold():
         stop_hiss()
 
+
 def start_hiss():
     active_hiss["start"] = time.time()
     active_hiss["cron"] = cron.interval("32ms", check_hiss)
+
 
 def on_hiss(noise_active: bool):
     if not setting_enabled.get():
@@ -89,5 +89,6 @@ def on_hiss(noise_active: bool):
         start_hiss()
     else:
         stop_hiss()
+
 
 noise.register('hiss', on_hiss)

--- a/dictation/debugging.py
+++ b/dictation/debugging.py
@@ -1,0 +1,94 @@
+import time
+import traceback
+
+from talon import (
+    actions,
+    cron,
+    noise,
+    ui,
+)
+from talon.mac.ui import Element
+
+HISS_DEBUG_ENABLED = True
+
+from talon import Module
+
+mod = Module()
+setting_enabled = mod.setting(
+    "hiss_to_debug_accessibility",
+    type=bool,
+    default=False,
+    desc="Use a hissing sound to print accessibility debugging information to the Talon log.",
+)
+setting_threshold = mod.setting(
+    "hiss_to_debug_accessibility_threshold",
+    type=float,
+    default=0.35,
+    desc="If hiss_to_debug_accessibility is enabled, the hissing duration (in seconds) needed to trigger the debug output.",
+)
+
+@mod.action_class
+class Actions:
+
+    def debug_accessibility(el: Element = None):
+        """short function for debugging accessibility"""
+
+        if not el:
+            el = ui.focused_element()
+        
+        try:
+            # TODO(pcohen): make this work without Rich installed
+            from rich.console import Console
+            console = Console(color_system="truecolor", soft_wrap=True)
+
+            console.rule(f"{str(el)}'s attributes:")
+
+            # Attempt to sort the keys
+            d = {}
+            for k in sorted(el.attrs):
+                d[k] = el.get(k)
+
+            console.print(d, markup=False)
+            console.rule("Accessibility contents:")
+        except Exception as e:
+            print(f"Exception while debugging accessibility: \"{e}\":")
+            traceback.print_exc()
+
+active_hiss = {"cron": None}
+
+def hiss_over_threshold():
+    if not active_hiss.get("start"):
+        return False
+
+    return time.time() - active_hiss["start"] > setting_threshold.get()
+
+def stop_hiss():
+    trigger = hiss_over_threshold()
+
+    if active_hiss["cron"]:
+        cron.cancel(active_hiss["cron"])
+        active_hiss["cron"] = None
+
+    active_hiss["start"] = None
+
+    if trigger:
+        actions.user.debug_accessibility()
+
+def check_hiss():
+    if hiss_over_threshold():
+        stop_hiss()
+
+def start_hiss():
+    active_hiss["start"] = time.time()
+    active_hiss["cron"] = cron.interval("32ms", check_hiss)
+
+def on_hiss(noise_active: bool):
+    if not setting_enabled.get():
+        return
+
+    if noise_active:
+        start_hiss()
+    else:
+        stop_hiss()
+
+noise.register('hiss', on_hiss)

--- a/dictation/dictation_context.py
+++ b/dictation/dictation_context.py
@@ -1,0 +1,90 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from talon import Context, ui, Module, actions
+from talon.mac.ui import Element
+from talon.types import Span
+
+ctx = Context()
+ctx.matches = "os: mac"
+
+mod = Module()
+setting_accessibility_dictation = mod.setting(
+    "accessibility_dictation",
+    type=bool,
+    default=False,
+    desc="Use accessibility APIs to implement context aware dictation.",
+)
+
+# Default number of characters to use to acquire context. Somewhat arbitrary.
+# The current dictation formatter doesn't need very many, but that could change in the future.
+DEFAULT_CONTEXT_CHARACTERS = 30
+
+
+@dataclass
+class AccessibilityContext:
+    """Records the context needed for dictation"""
+    content: str
+    selection: Span
+
+    def left_context(self, num_chars: int = DEFAULT_CONTEXT_CHARACTERS) -> str:
+        """Returns `num_chars`' worth of context to the left of the cursor"""
+        start = max(0, self.selection.left - num_chars)
+        return self.content[start:self.selection.left]
+
+    def right_context(self, num_chars: int = DEFAULT_CONTEXT_CHARACTERS) -> str:
+        """Returns `num_chars`' worth of context to the right of the cursor"""
+        end = min(self.selection.right + num_chars, len(self.content))
+        return self.content[self.selection.right:end]
+
+
+@mod.action_class
+class ModActions:
+
+    def should_use_accessibility_dictation():
+        """Returns whether the"""
+        return setting_accessibility_dictation.get()
+
+    def accessibility_adjust_context_for_application(el: Element,
+                                                     context: AccessibilityContext) -> AccessibilityContext:
+        """Sometimes the accessibility context reported by the application is wrong, but fixable
+        in predictable ways (this is most common in electron apps).
+        
+        This method can be overwritten in those applications to do so.
+        """
+        return context
+
+    def accessibility_create_context(el: Element) -> Optional[AccessibilityContext]:
+        """Peeks the context in the given direction"""
+        if not actions.user.should_use_accessibility_dictation():
+            return None
+
+        if not el or not el.attrs:
+            # No accessibility support.
+            return None
+
+        context = AccessibilityContext(content=el.get("AXValue"), selection=el.AXSelectedTextRange)
+
+        # Support application-specific overrides:
+        context = actions.user.accessibility_adjust_context_for_application(el, context)
+
+        return context
+
+
+@ctx.action_class("self")
+class Actions:
+    """Wires this in to the knausj dictation formatter"""
+
+    def dictation_peek_left(clobber=False):
+        context = actions.user.accessibility_create_context(ui.focused_element())
+        if context is None:
+            return actions.next()
+
+        return context.left_context()
+
+    def dictation_peek_right():
+        context = actions.user.accessibility_create_context(ui.focused_element())
+        if context is None:
+            return actions.next()
+
+        return context.right_context()

--- a/dictation/dictation_context.py
+++ b/dictation/dictation_context.py
@@ -65,7 +65,11 @@ class ModActions:
             # No accessibility support.
             return None
 
-        context = AccessibilityContext(content=el.get("AXValue"), selection=el.get("AXSelectedTextRange"))
+        # NOTE(pcohen): In Microsoft apps (Word, OneNote). 
+        selection = el.get("AXSelectedTextRange")
+        if selection is None:
+            selection = Span(0, 0)
+        context = AccessibilityContext(content=el.get("AXValue"), selection=selection)
 
         # Support application-specific overrides:
         context = actions.user.accessibility_adjust_context_for_application(el, context)

--- a/dictation/dictation_context.py
+++ b/dictation/dictation_context.py
@@ -48,8 +48,7 @@ class ModActions:
         return setting_accessibility_dictation.get()
     
     def dictation_current_element() -> Element:
-        """Returns the accessibility element that should be used for dictation (i.e.
-        the current input textbox).
+        """Returns the accessibility element that should be used for dictation (i.e. the current input textbox).
         
         This is almost always the focused (current) element, however, this action
         exists so that context can overwrite it, for applications with strange behavior.
@@ -58,10 +57,9 @@ class ModActions:
 
     def accessibility_adjust_context_for_application(el: Element,
                                                      context: AccessibilityContext) -> AccessibilityContext:
-        """Sometimes the accessibility context reported by the application is wrong, but fixable
-        in predictable ways (this is most common in Electron apps).
+        """Hook for applications to override the reported buffer contents/cursor location.
         
-        This method can be overwritten in those applications to do so.
+        Sometimes the accessibility context reported by the application is wrong, but fixable in predictable ways (this is most common in Electron apps). This method can be overwritten in those applications to do so.
         
         TODO(pcohen): it's a it strange to have both this and dictation_current_element;
         possibly refactor.
@@ -69,8 +67,7 @@ class ModActions:
         return context
 
     def accessibility_create_dictation_context(el: Element) -> Optional[AccessibilityContext]:
-        """Creates a `AccessibilityContext` representing the state of the input buffer
-        for dictation mode
+        """Creates a `AccessibilityContext` representing the state of the input buffer for dictation mode
         """
         if not actions.user.accessibility_dictation_enabled():
             return None

--- a/dictation/dictation_context.py
+++ b/dictation/dictation_context.py
@@ -78,7 +78,9 @@ class ModActions:
             # No accessibility support.
             return None
 
-        # NOTE(pcohen): In Microsoft apps (Word, OneNote). 
+        # NOTE(pcohen): In Microsoft apps (Word, OneNote), selection will be none when the cursor
+        # is that the start of the input buffer.
+        # TODO(pcohen): this should probably be an override
         selection = el.get("AXSelectedTextRange")
         if selection is None:
             selection = Span(0, 0)
@@ -94,6 +96,12 @@ class ModActions:
         return context
 
 
+# TODO(pcohen): relocate this
+class Colors:
+    RESET = '\033[0m'
+    RED = '\033[31m'
+    YELLOW = '\033[33m'
+
 @ctx.action_class("self")
 class Actions:
     """Wires this in to the knausj dictation formatter"""
@@ -103,11 +111,12 @@ class Actions:
             el = actions.user.dictation_current_element()
             context = actions.user.accessibility_create_dictation_context(el)
             if context is None:
+                print(f"{Colors.YELLOW}Accessibility not available for context-aware dictation{Colors.RESET}; falling back to cursor method")
                 return actions.next()
     
             return context.left_context()
         except Exception as e:
-            print(f"Error during accessibility dictation peeking: |{e}|")
+            print(f"{Colors.RED}Error while querying accessibility for context-aware dictation:{Colors.RESET} |{e}|")
             traceback.print_exc()
             
             # Fallback to the original (keystrokes) knausj method.
@@ -118,11 +127,13 @@ class Actions:
             el = actions.user.dictation_current_element()
             context = actions.user.accessibility_create_dictation_context(el)
             if context is None:
+                print(
+                    f"{Colors.YELLOW}Accessibility not available for context-aware dictation{Colors.RESET}; falling back to cursor method")
                 return actions.next()
-    
+
             return context.right_context()
         except Exception as e:
-            print(f"Error during accessibility dictation peeking: |{e}|")
+            print(f"{Colors.RED}Error while querying accessibility for context-aware dictation:{Colors.RESET} |{e}|")
             traceback.print_exc()
 
             # Fallback to the original (keystrokes) knausj method.

--- a/dictation/dictation_context.py
+++ b/dictation/dictation_context.py
@@ -80,7 +80,7 @@ class ModActions:
 
         # NOTE(pcohen): In Microsoft apps (Word, OneNote), selection will be none when the cursor
         # is that the start of the input buffer.
-        # TODO(pcohen): this should probably be an override
+        # TODO(pcohen): this should probably be an app-specific `accessibility_adjust_context_for_application`
         selection = el.get("AXSelectedTextRange")
         if selection is None:
             selection = Span(0, 0)

--- a/dictation/dictation_context.py
+++ b/dictation/dictation_context.py
@@ -1,5 +1,6 @@
 import traceback
 from dataclasses import dataclass
+from enum import Enum
 from typing import Optional
 
 from talon import Context, Module, actions, ui
@@ -96,7 +97,7 @@ class ModActions:
 
 
 # TODO(pcohen): relocate this
-class Colors:
+class Colors(Enum):
     RESET = '\033[0m'
     RED = '\033[31m'
     YELLOW = '\033[33m'
@@ -110,12 +111,12 @@ class Actions:
             el = actions.user.dictation_current_element()
             context = actions.user.accessibility_create_dictation_context(el)
             if context is None:
-                print(f"{Colors.YELLOW}Accessibility not available for context-aware dictation{Colors.RESET}; falling back to cursor method")
+                print(f"{Colors.YELLOW.value}Accessibility not available for context-aware dictation{Colors.RESET.value}; falling back to cursor method")
                 return actions.next()
-    
+
             return context.left_context()
         except Exception as e:
-            print(f"{Colors.RED}{type(e).__name__} while querying accessibility for context-aware dictation:{Colors.RESET} '{e}':")
+            print(f"{Colors.RED.value}{type(e).__name__} while querying accessibility for context-aware dictation:{Colors.RESET.value} '{e}':")
             traceback.print_exc()
             
             # Fallback to the original (keystrokes) knausj method.
@@ -127,12 +128,12 @@ class Actions:
             context = actions.user.accessibility_create_dictation_context(el)
             if context is None:
                 print(
-                    f"{Colors.YELLOW}Accessibility not available for context-aware dictation{Colors.RESET}; falling back to cursor method")
+                    f"{Colors.YELLOW.value}Accessibility not available for context-aware dictation{Colors.RESET.value}; falling back to cursor method")
                 return actions.next()
 
             return context.right_context()
         except Exception as e:
-            print(f"{Colors.RED}{type(e).__name__} while querying accessibility for context-aware dictation:{Colors.RESET} '{e}':")
+            print(f"{Colors.RED.value}{type(e).__name__} while querying accessibility for context-aware dictation:{Colors.RESET.value} '{e}':")
             traceback.print_exc()
 
             # Fallback to the original (keystrokes) knausj method.

--- a/dictation/dictation_context.py
+++ b/dictation/dictation_context.py
@@ -2,7 +2,7 @@ import traceback
 from dataclasses import dataclass
 from typing import Optional
 
-from talon import Context, ui, Module, actions
+from talon import Context, Module, actions, ui
 from talon.mac.ui import Element
 from talon.types import Span
 
@@ -42,15 +42,16 @@ class AccessibilityContext:
 @mod.action_class
 class ModActions:
 
-    def accessibility_dictation_enabled():
-        """Just exports `setting_accessibility_dictation` for use in other files"""
+    def accessibility_dictation_enabled() -> bool:
+        """Returns whether accessibility dictation should be used"""
+        # NB: for access within other files, since they can't import `setting_accessibility_dictation`
         return setting_accessibility_dictation.get()
     
     def dictation_current_element() -> Element:
-        """Returns the accessibility element that should be use for dictation (i.e.
+        """Returns the accessibility element that should be used for dictation (i.e.
         the current input textbox).
         
-        This is always always the focused (current) element, however, this function
+        This is almost always the focused (current) element, however, this action
         exists so that context can overwrite it, for applications with strange behavior.
         """
         return ui.focused_element()
@@ -105,7 +106,7 @@ class Colors:
 
 @ctx.action_class("self")
 class Actions:
-    """Wires this in to the knausj dictation formatter"""
+    """Wires this into the knausj dictation formatter"""
 
     def dictation_peek_left(clobber=False):
         try:

--- a/dictation/dictation_context.py
+++ b/dictation/dictation_context.py
@@ -1,3 +1,4 @@
+import traceback
 from dataclasses import dataclass
 from typing import Optional
 
@@ -86,15 +87,29 @@ class Actions:
     """Wires this in to the knausj dictation formatter"""
 
     def dictation_peek_left(clobber=False):
-        context = actions.user.accessibility_create_dictation_context(ui.focused_element())
-        if context is None:
-            return actions.next()
-
-        return context.left_context()
+        try:
+            context = actions.user.accessibility_create_dictation_context(ui.focused_element())
+            if context is None:
+                return actions.next()
+    
+            return context.left_context()
+        except Exception as e:
+            print(f"Error during accessibility dictation peeking: |{e}|")
+            traceback.print_exc()
+            
+            # Fallback to the original (keystrokes) knausj method.
+            actions.next()
 
     def dictation_peek_right():
-        context = actions.user.accessibility_create_dictation_context(ui.focused_element())
-        if context is None:
-            return actions.next()
+        try:
+            context = actions.user.accessibility_create_dictation_context(ui.focused_element())
+            if context is None:
+                return actions.next()
+    
+            return context.right_context()
+        except Exception as e:
+            print(f"Error during accessibility dictation peeking: |{e}|")
+            traceback.print_exc()
 
-        return context.right_context()
+            # Fallback to the original (keystrokes) knausj method.
+            actions.next()

--- a/dictation/dictation_context.py
+++ b/dictation/dictation_context.py
@@ -65,7 +65,7 @@ class ModActions:
             # No accessibility support.
             return None
 
-        context = AccessibilityContext(content=el.get("AXValue"), selection=el.AXSelectedTextRange)
+        context = AccessibilityContext(content=el.get("AXValue"), selection=el.get("AXSelectedTextRange"))
 
         # Support application-specific overrides:
         context = actions.user.accessibility_adjust_context_for_application(el, context)

--- a/dictation/dictation_context.py
+++ b/dictation/dictation_context.py
@@ -45,6 +45,15 @@ class ModActions:
     def accessibility_dictation_enabled():
         """Just exports `setting_accessibility_dictation` for use in other files"""
         return setting_accessibility_dictation.get()
+    
+    def dictation_current_element() -> Element:
+        """Returns the accessibility element that should be use for dictation (i.e.
+        the current input textbox).
+        
+        This is always always the focused (current) element, however, this function
+        exists so that context can overwrite it, for applications with strange behavior.
+        """
+        return ui.focused_element()
 
     def accessibility_adjust_context_for_application(el: Element,
                                                      context: AccessibilityContext) -> AccessibilityContext:
@@ -52,6 +61,9 @@ class ModActions:
         in predictable ways (this is most common in Electron apps).
         
         This method can be overwritten in those applications to do so.
+        
+        TODO(pcohen): it's a it strange to have both this and dictation_current_element;
+        possibly refactor.
         """
         return context
 
@@ -88,7 +100,8 @@ class Actions:
 
     def dictation_peek_left(clobber=False):
         try:
-            context = actions.user.accessibility_create_dictation_context(ui.focused_element())
+            el = actions.user.dictation_current_element()
+            context = actions.user.accessibility_create_dictation_context(el)
             if context is None:
                 return actions.next()
     
@@ -102,7 +115,8 @@ class Actions:
 
     def dictation_peek_right():
         try:
-            context = actions.user.accessibility_create_dictation_context(ui.focused_element())
+            el = actions.user.dictation_current_element()
+            context = actions.user.accessibility_create_dictation_context(el)
             if context is None:
                 return actions.next()
     

--- a/dictation/dictation_context.py
+++ b/dictation/dictation_context.py
@@ -74,6 +74,10 @@ class ModActions:
         # Support application-specific overrides:
         context = actions.user.accessibility_adjust_context_for_application(el, context)
 
+        # If we don't appear to have any accessibility information, don't use it.
+        if context.content is None or context.selection is None:
+            return None
+
         return context
 
 

--- a/dictation/dictation_context.py
+++ b/dictation/dictation_context.py
@@ -84,6 +84,7 @@ class ModActions:
         selection = el.get("AXSelectedTextRange")
         if selection is None:
             selection = Span(0, 0)
+            
         context = AccessibilityContext(content=el.get("AXValue"), selection=selection)
 
         # Support application-specific overrides:
@@ -116,7 +117,7 @@ class Actions:
     
             return context.left_context()
         except Exception as e:
-            print(f"{Colors.RED}Error while querying accessibility for context-aware dictation:{Colors.RESET} |{e}|")
+            print(f"{Colors.RED}{type(e).__name__} while querying accessibility for context-aware dictation:{Colors.RESET} '{e}':")
             traceback.print_exc()
             
             # Fallback to the original (keystrokes) knausj method.
@@ -133,7 +134,7 @@ class Actions:
 
             return context.right_context()
         except Exception as e:
-            print(f"{Colors.RED}Error while querying accessibility for context-aware dictation:{Colors.RESET} |{e}|")
+            print(f"{Colors.RED}{type(e).__name__} while querying accessibility for context-aware dictation:{Colors.RESET} '{e}':")
             traceback.print_exc()
 
             # Fallback to the original (keystrokes) knausj method.

--- a/dictation/dictation_context.py
+++ b/dictation/dictation_context.py
@@ -61,10 +61,10 @@ class ModActions:
         """Hook for applications to override the reported buffer contents/cursor location.
         
         Sometimes the accessibility context reported by the application is wrong, but fixable in predictable ways (this is most common in Electron apps). This method can be overwritten in those applications to do so.
-        
-        TODO(pcohen): it's a it strange to have both this and dictation_current_element;
-        possibly refactor.
         """
+        
+        # TODO(pcohen): it's a it strange to have both this and dictation_current_element;
+        # possibly refactor.
         return context
 
     def accessibility_create_dictation_context(el: Element) -> Optional[AccessibilityContext]:

--- a/dictation/dictation_context.py
+++ b/dictation/dictation_context.py
@@ -41,22 +41,24 @@ class AccessibilityContext:
 @mod.action_class
 class ModActions:
 
-    def should_use_accessibility_dictation():
-        """Returns whether the"""
+    def accessibility_dictation_enabled():
+        """Just exports `setting_accessibility_dictation` for use in other files"""
         return setting_accessibility_dictation.get()
 
     def accessibility_adjust_context_for_application(el: Element,
                                                      context: AccessibilityContext) -> AccessibilityContext:
         """Sometimes the accessibility context reported by the application is wrong, but fixable
-        in predictable ways (this is most common in electron apps).
+        in predictable ways (this is most common in Electron apps).
         
         This method can be overwritten in those applications to do so.
         """
         return context
 
-    def accessibility_create_context(el: Element) -> Optional[AccessibilityContext]:
-        """Peeks the context in the given direction"""
-        if not actions.user.should_use_accessibility_dictation():
+    def accessibility_create_dictation_context(el: Element) -> Optional[AccessibilityContext]:
+        """Creates a `AccessibilityContext` representing the state of the input buffer
+        for dictation mode
+        """
+        if not actions.user.accessibility_dictation_enabled():
             return None
 
         if not el or not el.attrs:
@@ -76,14 +78,14 @@ class Actions:
     """Wires this in to the knausj dictation formatter"""
 
     def dictation_peek_left(clobber=False):
-        context = actions.user.accessibility_create_context(ui.focused_element())
+        context = actions.user.accessibility_create_dictation_context(ui.focused_element())
         if context is None:
             return actions.next()
 
         return context.left_context()
 
     def dictation_peek_right():
-        context = actions.user.accessibility_create_context(ui.focused_element())
+        context = actions.user.accessibility_create_dictation_context(ui.focused_element())
         if context is None:
             return actions.next()
 

--- a/dictation/electron.py
+++ b/dictation/electron.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from talon import Context, ui, Module, actions
+from talon import Context, Module, actions, ui
 from talon.mac.ui import App
 from talon.ui import UIErr
 
@@ -9,7 +9,7 @@ ctx.matches = "os: mac"
 
 mod = Module()
 setting_electron_accessibility = mod.setting(
-    "electron_accessibility",
+    "enable_electron_accessibility",
     type=bool,
     default=False,
     desc="Tells Electron apps to enable their accessibility trees, so that you can use accessibility dictation with them. Note that this could cause worse performance, depending on the app.",

--- a/dictation/electron.py
+++ b/dictation/electron.py
@@ -8,7 +8,7 @@ ctx = Context()
 ctx.matches = "os: mac"
 
 mod = Module()
-setting_accessibility_dictation = mod.setting(
+setting_electron_accessibility = mod.setting(
     "electron_accessibility",
     type=bool,
     default=False,
@@ -30,7 +30,7 @@ class ModActions:
 
 
 def app_activate(app):
-    if setting_accessibility_dictation.get():
+    if setting_electron_accessibility.get():
         actions.user.enable_electron_accessibility(app)
 
 ui.register("app_activate", app_activate)

--- a/dictation/electron.py
+++ b/dictation/electron.py
@@ -24,8 +24,8 @@ class ModActions:
         
         try:
             app.element.AXManualAccessibility = True
-        except UIErr as e:
-            # this will raise "Error setting element attribute" even on success.
+        except UIErr:
+            # This will raise "Error setting element attribute" even on success.
             pass
 
 

--- a/dictation/electron.py
+++ b/dictation/electron.py
@@ -1,0 +1,24 @@
+from typing import Optional
+
+from talon import Context, ui, Module
+from talon.mac.ui import App
+from talon.ui import UIErr
+
+ctx = Context()
+ctx.matches = "os: mac"
+
+mod = Module()
+
+@mod.action_class
+class ModActions:
+    def enable_electron_accessibility(app: Optional[App] = None):
+        """Enables AX support in Electron - may affect performance"""
+        if not app:
+            app = ui.active_app()
+        
+        try:
+            app.element.AXManualAccessibility = True
+        except UIErr as e:
+            # It's expected to get "Error setting element attribute", 
+            pass
+

--- a/dictation/electron.py
+++ b/dictation/electron.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from talon import Context, ui, Module
+from talon import Context, ui, Module, actions
 from talon.mac.ui import App
 from talon.ui import UIErr
 
@@ -8,6 +8,12 @@ ctx = Context()
 ctx.matches = "os: mac"
 
 mod = Module()
+setting_accessibility_dictation = mod.setting(
+    "electron_accessibility",
+    type=bool,
+    default=False,
+    desc="Tells Electron apps to enable their accessibility trees, so that you can use accessibility dictation with them. Note that this could cause worse performance, depending on the app.",
+)
 
 @mod.action_class
 class ModActions:
@@ -19,6 +25,12 @@ class ModActions:
         try:
             app.element.AXManualAccessibility = True
         except UIErr as e:
-            # It's expected to get "Error setting element attribute", 
+            # this will raise "Error setting element attribute" even on success.
             pass
 
+
+def app_activate(app):
+    if setting_accessibility_dictation.get():
+        actions.user.enable_electron_accessibility(app)
+
+ui.register("app_activate", app_activate)


### PR DESCRIPTION
No rush on reviewing this! I figured it would be good to get your thoughts on this first batch of changes, before I go on to push more stuff. I'm probably going to focus on cursorless-on-JetBrains for the rest of the weekend so I'm not blocked on this review.

In this change:
- using AX to acquire context for dictation formatters
- APIs for overriding in specific apps, a sample override for Messages.app
- the ability to automatically enable AX for Electron
- basic debugging of accessibility using hissing

My thought is the `experimental` branch can be a sort of middle ground between `main` and our feature branches. Ambitious beta testers could use it and it also gives us a place to merge our development changes together and test them together. We can promote it to `main` afterwards.